### PR TITLE
Fix contest highlight bug when page changes

### DIFF
--- a/src/core/modules/contestRankingPageFriendsHighlighter.ts
+++ b/src/core/modules/contestRankingPageFriendsHighlighter.ts
@@ -9,6 +9,39 @@ export class contestRankingPageFriendsHighlighter implements IModule {
     pages = [PageType.CONTEST];
     private friendUsernames: Set<string> = new Set();
 
+    private clearHighlights() {
+        const rows = document.querySelectorAll<HTMLDivElement>(
+            Selectors.lc.contest.ranking.container.table_container.original_table.row
+        );
+
+        const rankDivs = document.querySelectorAll<HTMLDivElement>(
+            Selectors.lc.contest.ranking.container.table_container.original_table.rank_div
+        );
+
+        rows.forEach(row => {
+            row.style.background = "";
+            row.style.border = "";
+            row.style.borderLeft = "";
+            row.style.borderTopRightRadius = "";
+            row.style.borderBottomRightRadius = "";
+            row.style.transition = "";
+            row.style.position = "";
+            row.style.zIndex = "";
+        });
+
+        rankDivs.forEach(rankDiv => {
+            rankDiv.style.background = "";
+            rankDiv.style.border = "";
+            rankDiv.style.borderRight = "";
+            rankDiv.style.borderTopLeftRadius = "";
+            rankDiv.style.borderBottomLeftRadius = "";
+            rankDiv.style.transition = "";
+            rankDiv.style.position = "";
+            rankDiv.style.zIndex = "";
+        });
+    }
+
+
     apply(): void {
         const observer = new MutationObserver(() => this.action());
         observer.observe(document.body, { childList: true, subtree: true });
@@ -17,6 +50,7 @@ export class contestRankingPageFriendsHighlighter implements IModule {
 
     async action() {
         try {
+            this.clearHighlights();
             const friends = await FriendManager.getFriendList();
             if (!friends.length) return;
 


### PR DESCRIPTION
## Fix: Friend highlight persists across contest ranking pages (#48)

### What was happening
When switching pages in the contest rankings, friend highlights sometimes carried over to the next or previous page.  
This happened because LeetCode reuses table rows and the previously applied inline styles were never cleared.

### What I changed
I added a small cleanup step before applying highlights:
- A new `clearHighlights()` function removes any existing highlight styles
- It runs at the start of `action()` so each page starts fresh

### Result
- Highlights now appear only on pages where the friend is actually present
- Moving back and forth between pages no longer leaves stale highlights

https://github.com/user-attachments/assets/11535878-405a-4ae1-9273-bf9af0c25314



Fixes #48 
